### PR TITLE
chore(release): publish v0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orpc-mcp",
   "type": "module",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "packageManager": "pnpm@11.10.0",
   "description": "Serve an oRPC router as an MCP server — tools, resources, and prompts over Streamable HTTP or stdio.",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- record the published `orpc-mcp@0.1.2` package version
- release MCP 2026-07-28 protocol support
- release request-context catalog authorization

## Verification

- lint passed
- typecheck passed
- 150 tests passed
- build passed
- npm registry reports `latest: 0.1.2`