### PR TITLE
chore: release v0.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orpc-mcp",
   "type": "module",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "packageManager": "pnpm@11.10.0",
   "description": "Serve an oRPC router as an MCP server — tools, resources, and prompts over Streamable HTTP or stdio.",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump orpc-mcp to 0.1.3 after the contract-first execution fix

## Verification
- bun test (118 passed)
- bun run type:check
- bun run lint
- bun run build

GitHub Actions is currently blocked by an account billing lock; local verification passed.